### PR TITLE
feat: coordinate group targeting

### DIFF
--- a/Source/AntTest/AntTest.h
+++ b/Source/AntTest/AntTest.h
@@ -55,9 +55,13 @@ struct FUnitData
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	int32 SkelotInstanceID = 0;
 
-	/** @brief 队伍ID */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	int32 TeamID = 0;
+        /** @brief 队伍ID */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite)
+        int32 TeamID = 0;
+
+        /** @brief 组ID */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite)
+        int32 GroupID = 0;
 
 	/** @brief 当前目标代理句柄 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)


### PR DESCRIPTION
## Summary
- track team and group IDs for each unit and cache group versus group targets
- extend quadtree with group filtering to search nearest enemy in a specific group
- expose group-aware AddUnit API and store group IDs in unit data

## Testing
- `make test` (fails: No rule to make target 'test')

------
https://chatgpt.com/codex/tasks/task_e_689b1234c88c832ca3a64c17cfaffa51