### PR TITLE
feat: continuously spawn meteors

### DIFF
--- a/Source/AntTest/Private/Actors/MeteorProjectile.cpp
+++ b/Source/AntTest/Private/Actors/MeteorProjectile.cpp
@@ -1,0 +1,70 @@
+/**
+ * @file MeteorProjectile.cpp
+ * @brief 陨石Actor实现文件
+ */
+
+#include "Actors/MeteorProjectile.h"
+
+#include "BFSubjectiveAgentComponent.h"
+#include "Kismet/GameplayStatics.h"
+
+AMeteorProjectile::AMeteorProjectile()
+{
+    PrimaryActorTick.bCanEverTick = true;
+}
+
+void AMeteorProjectile::Init(const FVector& InTargetLocation, int32 InInstigatorTeam)
+{
+    TargetLocation = InTargetLocation;
+    InstigatorTeam = InInstigatorTeam;
+    SetActorLocation(TargetLocation + FVector(0.f, 0.f, 1000.f));
+}
+
+void AMeteorProjectile::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void AMeteorProjectile::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    FVector NewLocation = GetActorLocation();
+    NewLocation.Z -= FallSpeed * DeltaSeconds;
+    SetActorLocation(NewLocation);
+
+    if (NewLocation.Z <= TargetLocation.Z)
+    {
+        Explode();
+    }
+}
+
+void AMeteorProjectile::Explode()
+{
+    // 查询范围内的士兵
+    TArray<FOverlapResult> Overlaps;
+    FCollisionShape Sphere = FCollisionShape::MakeSphere(DamageRadius);
+    FCollisionQueryParams Params(SCENE_QUERY_STAT(MeteorDamage), false, this);
+
+    GetWorld()->OverlapMultiByChannel(Overlaps, TargetLocation, FQuat::Identity, ECC_Pawn, Sphere, Params);
+
+    for (const FOverlapResult& Res : Overlaps)
+    {
+        AActor* HitActor = Res.GetActor();
+        if (!HitActor)
+        {
+            continue;
+        }
+
+        if (UBFSubjectiveAgentComponent* Comp = HitActor->FindComponentByClass<UBFSubjectiveAgentComponent>())
+        {
+            if (Comp->TeamIndex != InstigatorTeam)
+            {
+                UGameplayStatics::ApplyDamage(HitActor, Damage, nullptr, this, UDamageType::StaticClass());
+            }
+        }
+    }
+
+    Destroy();
+}
+

--- a/Source/AntTest/Private/Actors/MeteorRainActor.cpp
+++ b/Source/AntTest/Private/Actors/MeteorRainActor.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file MeteorRainActor.cpp
+ * @brief 陨石雨生成Actor实现文件
+ */
+
+#include "Actors/MeteorRainActor.h"
+#include "Actors/MeteorProjectile.h"
+
+#include "BFSubjectiveAgentComponent.h"
+#include "TimerManager.h"
+
+AMeteorRainActor::AMeteorRainActor()
+{
+    PrimaryActorTick.bCanEverTick = false;
+}
+
+void AMeteorRainActor::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (UBFSubjectiveAgentComponent* Comp = FindComponentByClass<UBFSubjectiveAgentComponent>())
+    {
+        OwnerTeam = Comp->TeamIndex;
+    }
+
+    GetWorld()->GetTimerManager().SetTimer(SpawnTimer, this, &AMeteorRainActor::SpawnSingleMeteor, MeteorInterval, true);
+}
+
+void AMeteorRainActor::SpawnSingleMeteor()
+{
+    if (!MeteorClass)
+    {
+        return;
+    }
+
+    FVector TargetLocation = GetActorLocation();
+    AMeteorProjectile* Meteor = GetWorld()->SpawnActor<AMeteorProjectile>(MeteorClass, TargetLocation + FVector(0.f,0.f,1000.f), FRotator::ZeroRotator);
+    if (Meteor)
+    {
+        Meteor->Init(TargetLocation, OwnerTeam);
+    }
+}
+

--- a/Source/AntTest/Public/Actors/MeteorProjectile.h
+++ b/Source/AntTest/Public/Actors/MeteorProjectile.h
@@ -1,0 +1,61 @@
+/**
+ * @file MeteorProjectile.h
+ * @brief 陨石Actor头文件
+ * @details 定义了简单的陨石Actor, 用于从空中下落并在落地时造成范围伤害。
+ */
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "MeteorProjectile.generated.h"
+
+class UBFSubjectiveAgentComponent;
+
+/**
+ * @brief 陨石Actor
+ * @details 从生成点向下移动, 落地后对敌对队伍造成伤害。
+ */
+UCLASS()
+class ANTTEST_API AMeteorProjectile : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AMeteorProjectile();
+
+    /**
+     * @brief 初始化陨石
+     * @param InTargetLocation 落点位置
+     * @param InInstigatorTeam 施法者队伍ID
+     */
+    void Init(const FVector& InTargetLocation, int32 InInstigatorTeam);
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void Tick(float DeltaSeconds) override;
+
+    /**
+     * @brief 处理陨石爆炸与伤害
+     */
+    void Explode();
+
+private:
+    /** 陨石下落速度 */
+    UPROPERTY(EditDefaultsOnly, Category="Meteor")
+    float FallSpeed = 1200.f;
+
+    /** 伤害半径 */
+    UPROPERTY(EditDefaultsOnly, Category="Meteor")
+    float DamageRadius = 200.f;
+
+    /** 造成的基础伤害 */
+    UPROPERTY(EditDefaultsOnly, Category="Meteor")
+    float Damage = 50.f;
+
+    /** 预期落点 */
+    FVector TargetLocation;
+
+    /** 施法者队伍ID */
+    int32 InstigatorTeam = 0;
+};
+

--- a/Source/AntTest/Public/Actors/MeteorRainActor.h
+++ b/Source/AntTest/Public/Actors/MeteorRainActor.h
@@ -1,0 +1,49 @@
+/**
+ * @file MeteorRainActor.h
+ * @brief 陨石雨生成Actor头文件
+ * @details 在场景中持续生成陨石, 不再进行敌军检测。
+ */
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "MeteorRainActor.generated.h"
+
+class AMeteorProjectile;
+class UBFSubjectiveAgentComponent;
+
+/**
+ * @brief 陨石雨生成器
+ */
+UCLASS()
+class ANTTEST_API AMeteorRainActor : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    AMeteorRainActor();
+
+protected:
+    virtual void BeginPlay() override;
+
+    /**
+     * @brief 生成单个陨石
+     */
+    void SpawnSingleMeteor();
+
+private:
+    /** 陨石生成间隔 */
+    UPROPERTY(EditAnywhere, Category="Meteor")
+    float MeteorInterval = 0.3f;
+
+    /** 陨石Actor类 */
+    UPROPERTY(EditAnywhere, Category="Meteor")
+    TSubclassOf<AMeteorProjectile> MeteorClass;
+
+    /** 定时器句柄 */
+    FTimerHandle SpawnTimer;
+
+    /** 施法者队伍ID */
+    int32 OwnerTeam = 0;
+};
+


### PR DESCRIPTION
## Summary
- simplify `AMeteorRainActor` to endlessly spawn meteors at its own position
- remove enemy detection logic

## Testing
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689c6663ef50832c8b4a930d86224688